### PR TITLE
Gracefully handle empty chapter list

### DIFF
--- a/.builds/ubuntu.yml
+++ b/.builds/ubuntu.yml
@@ -3,6 +3,8 @@ image: ubuntu/bionic
 secrets:
   # Github deploy key: solely for mirroring to github
   - 89816c8b-4416-4a78-84ee-3ad77b485912
+  # PyPI token for pytaku:
+  - 8c42b8a6-d1b7-4af7-82f2-b8f1b6e085e2
 
 environment:
   # Ugly hack to prepend to PATH:
@@ -37,3 +39,7 @@ tasks:
       cd pytaku
       source ~/venv/bin/activate
       poetry build
+
+  - publish: |
+      cd pytaku
+      poetry publish

--- a/.builds/ubuntu.yml
+++ b/.builds/ubuntu.yml
@@ -13,6 +13,8 @@ environment:
 packages:
   - curl
   - python3.7-dev
+  - python3.7-venv
+  - python3-pip
 
 tasks:
   - mirror-to-github: |
@@ -24,11 +26,14 @@ tasks:
       git push -f github '*:*' --follow-tags
 
   - setup: |
+      python3.7 -m venv ~/venv
+      source ~/venv/bin/activate
       curl https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py -o get-poetry.py
-      python3.7 get-poetry.py -y
+      python get-poetry.py -y
       cd pytaku
       poetry install
 
   - build: |
       cd pytaku
+      source ~/venv/bin/activate
       poetry build

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@ Live demo: https://dev.pytaku.com (db may be hosed any time, also expect bugs)
 
 Production instance coming When It's Ready (tm).
 
+# Pytaku
+
+[![builds.sr.ht status](https://builds.sr.ht/~nhanb/pytaku/commits/ubuntu.yml.svg)](https://builds.sr.ht/~nhanb/pytaku/commits/ubuntu.yml?)
+
 Pytaku is a WIP web-based manga reader that keeps track of your reading
 progress and new chapter updates. Its design goals are:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytaku"
-version = "0.2.5"
+version = "0.2.6"
 description = ""
 authors = ["Bùi Thành Nhân <hi@imnhan.com>"]
 license = "AGPL-3.0-only"

--- a/src/mangoapi/__init__.py
+++ b/src/mangoapi/__init__.py
@@ -55,7 +55,7 @@ def get_title(title_id):
                 "groups": _extract_groups(chap),
                 **_parse_chapter_number(chap["chapter"]),
             }
-            for chap_id, chap in md_json["chapter"].items()
+            for chap_id, chap in md_json.get("chapter", {}).items()
             if chap["lang_code"] == "gb" and chap["group_name"] != "MangaPlus"
         ],
     }


### PR DESCRIPTION
Example case on Mangadex: https://mangadex.org/api/?id=44354&type=manga

Pytaku is failing: https://dev.pytaku.com/title/mangadex/44354